### PR TITLE
feat(ui): set NavigationRail to extended state in wide landscape

### DIFF
--- a/lib/pages/main/main.dart
+++ b/lib/pages/main/main.dart
@@ -42,46 +42,62 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) {
+    final ratio = MediaQuery.sizeOf(context).aspectRatio;
     return Scaffold(
-      body: buildBody(),
-      bottomNavigationBar: buildNavigationBar(),
-    );
-  }
-
-  Widget buildBody() {
-    return MediaQuery.of(context).size.width > 600
-        ? Row(
-            children: [
-              NavigationRail(
-                labelType: NavigationRailLabelType.all,
-                destinations: [
-                  for (final destination in buildCommonDestinations())
-                    NavigationRailDestination(
-                      icon: destination.$1,
-                      label: Text(destination.$2),
-                    )
-                ],
-                selectedIndex: _currentIndex,
-                onDestinationSelected: (int index) {
-                  setState(() {
-                    _currentIndex = index;
-                  });
-                },
-                leading: const SizedBox(),
-              ),
-              const VerticalDivider(thickness: 1, width: 1),
-              Expanded(
-                child: IndexedStack(
-                  index: _currentIndex,
-                  children: _pages,
+      body: ratio > 1.0
+          ? Row(
+              children: [
+                NavigationRail(
+                  extended: ratio > 1.5,
+                  labelType: ratio > 1.5
+                      ? NavigationRailLabelType.none
+                      : NavigationRailLabelType.all,
+                  destinations: [
+                    for (final destination in buildCommonDestinations())
+                      NavigationRailDestination(
+                        icon: destination.$1,
+                        label: Text(destination.$2),
+                      )
+                  ],
+                  selectedIndex: _currentIndex,
+                  onDestinationSelected: (int index) {
+                    setState(() {
+                      _currentIndex = index;
+                    });
+                  },
+                  leading: const SizedBox(),
                 ),
-              ),
-            ],
-          )
-        : IndexedStack(
-            index: _currentIndex,
-            children: _pages,
-          );
+                const VerticalDivider(thickness: 1, width: 1),
+                Expanded(
+                  child: IndexedStack(
+                    index: _currentIndex,
+                    children: _pages,
+                  ),
+                ),
+              ],
+            )
+          : IndexedStack(
+              index: _currentIndex,
+              children: _pages,
+            ),
+      bottomNavigationBar: ratio <= 1.0
+          ? NavigationBar(
+              onDestinationSelected: (int index) {
+                setState(() {
+                  _currentIndex = index;
+                });
+              },
+              selectedIndex: _currentIndex,
+              destinations: [
+                for (final destination in buildCommonDestinations())
+                  NavigationDestination(
+                    icon: destination.$1,
+                    label: destination.$2,
+                  )
+              ],
+            )
+          : null,
+    );
   }
 
   List<(Icon, String)> buildCommonDestinations() {
@@ -91,26 +107,6 @@ class _HomeState extends State<Home> {
       (const Icon(Icons.book), AppLocalizations.of(context)!.wordBook),
       (const Icon(Icons.settings), AppLocalizations.of(context)!.settings)
     ];
-  }
-
-  NavigationBar? buildNavigationBar() {
-    return MediaQuery.of(context).size.width < 600
-        ? NavigationBar(
-            onDestinationSelected: (int index) {
-              setState(() {
-                _currentIndex = index;
-              });
-            },
-            selectedIndex: _currentIndex,
-            destinations: [
-              for (final destination in buildCommonDestinations())
-                NavigationDestination(
-                  icon: destination.$1,
-                  label: destination.$2,
-                )
-            ],
-          )
-        : null;
   }
 
   @override


### PR DESCRIPTION
According to [Flutter API documentation](https://api.flutter.dev/flutter/material/NavigationRail/extended.html):
> extended property
>
> Indicates that the [NavigationRail](https://api.flutter.dev/flutter/material/NavigationRail-class.html) should be in the extended state.
> 
> The extended state has a wider rail container, and the labels are positioned next to the icons. [minExtendedWidth](https://api.flutter.dev/flutter/material/NavigationRail/minExtendedWidth.html) can be used to set the minimum width of the rail when it is in this state.
> 
> The rail will implicitly animate between the extended and normal state.
> 
> If the rail is going to be in the extended state, then the [labelType](https://api.flutter.dev/flutter/material/NavigationRail/labelType.html) must be set to [NavigationRailLabelType.none](https://api.flutter.dev/flutter/src_material_navigation_rail/NavigationRailLabelType.html).
>
> The default value is false.

![image](https://github.com/user-attachments/assets/4ba1359d-05da-4e7d-8e9e-a2ebbace8389)

In this pull request, extended state is enabled when `aspectRatio` is greater than 1.5, which means the ratio of width to height is larger than 1.5.

To avoid calling `MediaQuery.of` or `MediaQuery.sizeOf` repeatedly, function `buildBody()` and `buildNavigationBar()` is inlined in `build()`.