### PR TITLE
chore: adjust version code

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
         create("release") {
             keyAlias = keystoreProperties["keyAlias"] as String?
             keyPassword = keystoreProperties["keyPassword"] as String?
-            storeFile = keystoreProperties["storeFile"].let { file(it) }
+            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
             storePassword = keystoreProperties["storePassword"] as String?
         }
     }
@@ -95,7 +95,7 @@ dependencies {
     implementation("com.jakewharton.timber:timber:5.0.1")
 }
 
-val abiCodes = mapOf("x86_64" to 1, "armeabi-v7a" to 2, "arm64-v8a" to 3)
+val abiCodes = mapOf("x86_64" to 1, "armeabi-v7a" to 5, "arm64-v8a" to 5)
 
 androidComponents {
     onVariants { variant ->
@@ -105,7 +105,7 @@ androidComponents {
 
             val baseAbiCode = abiCodes[name]
             if (baseAbiCode != null) {
-                output.versionCode.set((output.versionCode.get() * 10) + baseAbiCode)
+                output.versionCode.set(baseAbiCode * 1000 + output.versionCode.get())
             }
         }
     }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -95,7 +95,7 @@ dependencies {
     implementation("com.jakewharton.timber:timber:5.0.1")
 }
 
-val abiCodes = mapOf("x86_64" to 1, "armeabi-v7a" to 5, "arm64-v8a" to 5)
+val abiCodes = mapOf("x86_64" to 0, "armeabi-v7a" to 4, "arm64-v8a" to 4)
 
 androidComponents {
     onVariants { variant ->
@@ -105,7 +105,7 @@ androidComponents {
 
             val baseAbiCode = abiCodes[name]
             if (baseAbiCode != null) {
-                output.versionCode.set(baseAbiCode * 1000 + output.versionCode.get())
+                output.versionCode.set(output.versionCode.get() * 10000 + baseAbiCode * 1000)
             }
         }
     }


### PR DESCRIPTION
Since I migrated build.gradle to build.gradle.kts, the Android versionCode got out of sync with the old system. This then caused deployment problems over at F-Droid. When I found out, I was about to be stuck at school and was really nervous, so I just kind of fudged a fix, which made the versionCode even messier.

This PR is to get the versionCode straightened out and make sure it plays nice with how F-Droid sorts APKs.

For example, 584000, 585000, 586000.