### PR TITLE
fix: add keybinder deb dependency

### DIFF
--- a/linux/packaging/deb/control
+++ b/linux/packaging/deb/control
@@ -5,6 +5,6 @@ Priority: optional
 Architecture: @ARCH@
 Maintainer: Mumulhl <mumulhl.666@gmail.com>
 Installed-Size: @INSTALLED_SIZE@
-Depends: libgtk-3-0, libglib2.0-0, libstdc++6, libayatana-appindicator3-1
+Depends: libgtk-3-0, libglib2.0-0, libstdc++6, libayatana-appindicator3-1, libkeybinder-3.0-0
 Description: A comprehensive dictionary application built with Flutter.
  Support MDX/MDD formats and offers a modern user experience with Material You design.


### PR DESCRIPTION
## Summary
- Add missing `libkeybinder-3.0-0` runtime dependency to the Debian package control template
- Ensures installing the .deb pulls in the library that provides `libkeybinder-3.0.so.0` on KDE neon/Ubuntu-based systems

Fixes #581

## Test Plan
- Not run per maintainer request; packaging metadata-only change